### PR TITLE
Fix clock time update bug

### DIFF
--- a/Assets/Scripts/UI/DecisionCards/DecisionCardManager.cs
+++ b/Assets/Scripts/UI/DecisionCards/DecisionCardManager.cs
@@ -46,11 +46,6 @@ public class DecisionCardManager : MonoBehaviour
             Debug.Log($"DecisionCardUiMaster assigned. We have {todaysCards.Count} pending cards. Showing them now.");
             /*uiMaster.gameObject.SetActive(true);
             uiMaster.GenerateTodaysCards();*/
-            
-            if(TimeManager.Instance != null)
-            {
-                TimeManager.Instance.SetTimePauseState(true);
-            }
         }
     }
     
@@ -706,7 +701,7 @@ public class DecisionCardManager : MonoBehaviour
     
     private void RestartTimeAfterCards()
     {
-        if (TimeManager.Instance != null)
+        if (TimeManager.Instance != null )
         {
             TimeManager.Instance.SetTimePauseState(false);
         }

--- a/Assets/Scripts/UI/DecisionCards/DecisionCardUiMaster.cs
+++ b/Assets/Scripts/UI/DecisionCards/DecisionCardUiMaster.cs
@@ -157,6 +157,7 @@ public class DecisionCardUiMaster : MonoBehaviour
            // No more cards
            Debug.Log("All cards processed for today");
            DecisionCardManager.Instance.OnAllCardsProcessed?.Invoke();
+           ResumeTimeAfterCards();
            ResetBackgroundColor();
            this.gameObject.SetActive(false); // Hide themaster UI 
        }


### PR DESCRIPTION
This pull request updates the logic for pausing and resuming game time when displaying decision cards. The main change is moving the responsibility for resuming time from the `DecisionCardManager` to the `DecisionCardUiMaster`, ensuring that time is resumed after all cards are processed, and removing the previous code that paused time.

**Time management changes:**

* Removed the code that paused time in `DecisionCardManager.SetUiMaster`, so the game no longer pauses automatically when decision cards are shown.
* Added a call to `ResumeTimeAfterCards()` in `DecisionCardUiMaster.ShowNextCard` to ensure game time resumes after all cards are processed.